### PR TITLE
Make DownloadFile optionally concurrent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,5 +27,6 @@ require (
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.3 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Thank you for building this! I'm using this for downloading files in the magnitude of over 1GB. I made this change in my fork and noticed a visible improvement.

---

Currently, the `DownloadFile` function downloads file parts sequentially. This leaves the bandwidth underutilized, especially when downloading a file with multiple parts.

This patch introduces optional concurrency to the `DownloadFile` function. When `api.SetConcurrency(n)` is called with `n > 1`, `DownloadFile` will download up to n parts of the file in parallel. This can significantly reduce the total download time for large files.

Since the order of the parts matters, the implementation ensures that the parts are written to the destination file in the correct order. By storing the downloaded parts in temp files and then merging them in order once all parts are downloaded.

### Benchmark

**Without concurrency**

<img width="2114" height="814" alt="image" src="https://github.com/user-attachments/assets/f9136c8d-06bc-480e-8577-f965c3db1c1b" />

**With concurrency**

<img width="1910" height="808" alt="image" src="https://github.com/user-attachments/assets/3813dc2c-55d3-4f1b-8344-b637c2732aa0" />